### PR TITLE
fix(android): pin onnxruntime to 1.22.0 for 16 KB page-size alignment

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,5 +65,8 @@ dependencies {
     implementation "com.google.flogger:flogger-system-backend:latest.release"
     implementation "com.google.guava:guava:27.0.1-android"
     implementation "com.google.protobuf:protobuf-javalite:3.19.1"
-    implementation "com.microsoft.onnxruntime:onnxruntime-android:latest.release"
+    // Pinned to 1.20.0+ which introduced 16 KB page-size alignment support
+    // (https://onnxruntime.ai/docs/build/android.html).
+    // "latest.release" may resolve to an older artifact on some Gradle setups.
+    implementation "com.microsoft.onnxruntime:onnxruntime-android:1.22.0"
 }


### PR DESCRIPTION
## Problem

Android 15 introduces 16 KB memory page support (required on Pixel 9+ and future devices). Apps with native libraries not aligned to 16 KB boundaries show an **Android App Compatibility** warning at launch and will fail alignment checks on devices with 16 KB pages enforced.

Running the app on an Android 15 emulator reports the following unaligned libraries:

```
lib/x86_64/libappmodules.so       : Unknown error
lib/x86_64/libopencv_java4.so     : Unknown error
lib/x86_64/libonnxruntime.so      : Unknown error
lib/x86_64/libonnxruntime4j_jni.so: Unknown error
```

## Root cause

`libonnxruntime.so` and `libonnxruntime4j_jni.so` originate from the transitive dependency:

```
com.microsoft.onnxruntime:onnxruntime-android:latest.release
```

Microsoft added 16 KB page-size alignment support in **ONNX Runtime 1.20.0** (see [ONNX Runtime Android build docs](https://onnxruntime.ai/docs/build/android.html)). Using `latest.release` can resolve to older artefacts on some Gradle setups, and the floating label makes it impossible to guarantee the fix.

## Fix

Pin `onnxruntime-android` to `1.22.0` (current latest, first stable release line with 16 KB support):

```diff
-    implementation "com.microsoft.onnxruntime:onnxruntime-android:latest.release"
+    // Pinned to 1.20.0+ which introduced 16 KB page-size alignment support.
+    implementation "com.microsoft.onnxruntime:onnxruntime-android:1.22.0"
```

## Remaining issue (needs upstream fix)

`libopencv_java4.so` and `libappmodules.so` come from the prebuilt AARs inside:

- `ai.quickpose:quickpose-mp:0.6`
- `ai.quickpose:quickpose-core:0.21`

These need to be **recompiled with `-Wl,-z,max-page-size=16384`** (or the equivalent NDK CMake flag `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON`) and republished to Maven. This cannot be fixed from the React Native wrapper — it requires rebuilding and republishing those Maven artifacts.

## References

- [Android 16 KB page size developer guide](https://developer.android.com/guide/practices/page-sizes)
- [ONNX Runtime 1.20 release notes](https://github.com/microsoft/onnxruntime/releases/tag/v1.20.0)
- [react-native-video fix (v6.17.0) — TheWidlarzGroup/react-native-video#4691](https://github.com/TheWidlarzGroup/react-native-video/pull/4691)